### PR TITLE
Wonderart-CRM #56 Vercel 배포 시 환경변수 작동하지 않는 버그 수정

### DIFF
--- a/lib/jwt.ts
+++ b/lib/jwt.ts
@@ -9,7 +9,7 @@ const DEFAULT_SIGN_OPTION: SignOption = {
 };
 
 export function signJwtAccessToken(payload: JwtPayload, options: SignOption = DEFAULT_SIGN_OPTION) {
-  const secret_key = process.env.SECRET_KEY;
+  const secret_key = process.env.NEXT_PUBLIC_SECRET_KEY;
   const token = jwt.sign(payload, secret_key!, options);
 
   return token;
@@ -17,7 +17,7 @@ export function signJwtAccessToken(payload: JwtPayload, options: SignOption = DE
 
 export function verifyJwt(token: string) {
   try {
-    const secret_key = process.env.SECRET_KEY;
+    const secret_key = process.env.NEXT_PUBLIC_SECRET_KEY;
     const decoded = jwt.verify(token, secret_key!);
 
     return decoded as JwtPayload;

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -16,7 +16,7 @@ const handler = NextAuth({
       },
       async authorize(credentials, req) {
         // Add logic here to look up the user from the credentials supplied
-        const res = await fetch(`${process.env.NEXTAUTH_URL}/api/login`, {
+        const res = await fetch(`${process.env.NEXT_PUBLIC_NEXTAUTH_URL}/api/login`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',


### PR DESCRIPTION
# Wonderart-CRM #56 Vercel 배포 시 환경변수 작동하지 않는 버그 수정

## 작업 목적

- Vercel에 배포 시 환경 변수가 동작하지 않는 에러를 수정하기 위해 작업.

## 작업 내용

- 환경 변수에 `NEXT_PUBLIC_` 추가

## 참고 내용
- https://nextjs.org/docs/pages/building-your-application/configuring/environment-variables#bundling-environment-variables-for-the-browser
- https://production-grade-nextjs.vercel.app/lesson/12-deploying
 

## 해당 PR에서 테스트할 방법을 작성해 주세요
- `.env` 파일이 변경되었기에 담당자(GiSeok-Hong)에게 문의해 주세요.



## 관련된 이슈, 커밋, PR

- PR #53 
- ISSUE #56

## 체크리스트

- [x] 빌드 체크 하셨나요?
- [x] PR의 내용을 짐작할 수 있는 적절한 제목을 썼나요?
- [x] 작업 목적은 명확하게 의미 전달이 가능한가요?
- [x] 작업 내용은 간결하게 끝나는 문장인가요?
- [x] 첨부는 기능을 충분히 포함하고 있나요?
- [x] 관련 이슈나 티켓, PR을 포함했나요?
