### PR TITLE
Wonderart-CRM #58 Student 테이블에 '등록여부' 컬럼 추가

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -31,8 +31,9 @@ model Student {
   importantActivity ArtActivity @default(DRAWING)
   interestingActivity ArtActivity @default(DRAWING)
   caution String? @db.VarChar(200)
-  agree Boolean
+  isCopyrightAgree Boolean @default(true)
   teacherMemo String? @db.VarChar(200)
+  isRegister Boolean @default(true)
 }
 
 model Guardian {

--- a/src/app/api/student/[id]/route.ts
+++ b/src/app/api/student/[id]/route.ts
@@ -1,5 +1,5 @@
-import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "../../../../../lib/prisma";
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '../../../../../lib/prisma';
 
 type Params = {
   id: string;
@@ -9,7 +9,7 @@ export async function PUT(request: NextRequest, context: { params: Params }) {
   const { id } = context.params;
   const body = await request.json();
   if (body === undefined) {
-    return NextResponse.json({ error: 'Bad Request' }, { status: 400 })
+    return NextResponse.json({ error: 'Bad Request' }, { status: 400 });
   }
 
   const {
@@ -30,6 +30,7 @@ export async function PUT(request: NextRequest, context: { params: Params }) {
     interestingActivity,
     teacherMemo,
     caution,
+    isRegister,
   } = body;
 
   try {
@@ -43,7 +44,7 @@ export async function PUT(request: NextRequest, context: { params: Params }) {
           update: {
             name: guardianName,
             phone: guardianPhone,
-          }
+          },
         },
         name,
         phone,
@@ -57,11 +58,11 @@ export async function PUT(request: NextRequest, context: { params: Params }) {
         interestingActivity,
         teacherMemo,
         caution,
-      }
-    })
+        isRegister,
+      },
+    });
     return NextResponse.json({ data: result }, { status: 200 });
   } catch (error) {
     return NextResponse.json({ message: '학생 정보 수정에 실패했습니다.' }, { status: 500 });
   }
-
 }

--- a/src/app/registration/api/route.ts
+++ b/src/app/registration/api/route.ts
@@ -21,9 +21,10 @@ export async function POST(req: Request) {
     importantActivity,
     interestingActivity,
     caution,
-    agree,
+    isCopyrightAgree,
     guardianName,
     guardianPhone,
+    isRegister,
   } = data;
 
   try {
@@ -43,7 +44,8 @@ export async function POST(req: Request) {
         importantActivity,
         interestingActivity,
         caution,
-        agree,
+        isCopyrightAgree,
+        isRegister,
         guardian: {
           create: { name: guardianName, phone: guardianPhone },
         },
@@ -62,8 +64,8 @@ export async function POST(req: Request) {
       },
     });
 
-    return NextResponse.json({ message: '학원생 등록이 완료되었습니다..', success: true, status: 200 });
+    return NextResponse.json({ message: '학원생 등록이 완료되었습니다.', success: true, status: 201 });
   } catch {
-    return NextResponse.json({ message: '학원생 등록 실패', success: false, status: 400 });
+    return NextResponse.json({ message: '학원생 등록에 실패하였습니다.', success: false, status: 400 });
   }
 }

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -2,6 +2,7 @@
 
 import { useForm } from 'react-hook-form';
 import { ArtActivity, ReasonForChoosing, Sex } from '@prisma/client';
+import { useRouter } from 'next/navigation';
 
 const DIV_CLASS = 'mb-5 ';
 const LABEL_CLASS = 'text-xl font-bold inline-block min-w-label ';
@@ -84,10 +85,11 @@ type InputStudent = {
   importantActivity: ArtActivity;
   interestingActivity: ArtActivity;
   caution?: string;
-  agree: string;
+  isCopyrightAgree: string;
 };
 
 export default function Form() {
+  const router = useRouter();
   const phoneReg = /^01([0|1|6|7|8|9])([0-9]{7,8})$/;
 
   const {
@@ -115,7 +117,7 @@ export default function Form() {
       importantActivity: 'DRAWING',
       interestingActivity: 'DRAWING',
       caution: '',
-      agree: 'NO',
+      isCopyrightAgree: 'NO',
     },
   });
 
@@ -125,7 +127,7 @@ export default function Form() {
     const time = [Number(data.time1)];
     if (data.time2 !== 0) time.push(Number(data.time2));
 
-    const agree = data.agree === 'YES' ? true : false;
+    const isCopyrightAgree = data.isCopyrightAgree === 'YES' ? true : false;
 
     const body = {
       entranceDate: data.entranceDate,
@@ -142,18 +144,30 @@ export default function Form() {
       importantActivity: data.importantActivity,
       interestingActivity: data.interestingActivity,
       caution: data.caution,
-      agree,
+      isCopyrightAgree,
       guardianName: data.guardianName,
       guardianPhone: data.guardianPhone,
+      isRegister: true,
     };
 
-    const res = await fetch('/registration/api', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(body),
-    }).then((res) => res.json());
+    try {
+      const res = await fetch('/registration/api', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(body),
+      }).then((res) => res.json());
+
+      alert(`${res.message}`);
+
+      if (res?.success) {
+        return router.push('/');
+      }
+    } catch (error) {
+      console.log('학생등록 에러 ::: ' + error);
+      alert('알 수 없는 에러로 학생등록에 실패했습니다.');
+    }
   };
 
   return (
@@ -580,7 +594,7 @@ export default function Form() {
       </div>
       <div className={DIV_CLASS}>
         <label
-          htmlFor="agree"
+          htmlFor="isCopyrightAgree"
           className={LABEL_CLASS + UNDERLINE_CLASS}
         >
           원더아트 스튜디오에서 작업한 모든 작품과 사진의 저작권은 <br />
@@ -591,7 +605,7 @@ export default function Form() {
             type="radio"
             className="mr-2"
             value="YES"
-            {...register('agree')}
+            {...register('isCopyrightAgree')}
           />
           예
         </label>
@@ -600,7 +614,7 @@ export default function Form() {
             type="radio"
             className="mr-2"
             value="NO"
-            {...register('agree')}
+            {...register('isCopyrightAgree')}
           />
           아니오
         </label>

--- a/src/components/StudentDetailForm.tsx
+++ b/src/components/StudentDetailForm.tsx
@@ -97,7 +97,7 @@ export default function StudentDetailForm({
       birthDate: moment(birthDate, 'YYYY.MM.DD').toDate(),
       day: day.map(Number).filter(Boolean),
       time: time.map(Number).filter(Boolean),
-      isRegister: isRegister === 'YES' ? true : false,
+      isRegister: isRegister === 'YES',
     };
     try {
       await fetch(`/api/student/${studentData?.id}`, {

--- a/src/components/StudentDetailForm.tsx
+++ b/src/components/StudentDetailForm.tsx
@@ -31,6 +31,7 @@ type UpdateStudentForm = {
   interestingActivity: string;
   teacherMemo: string | null;
   caution: string | null;
+  isRegister: 'YES' | 'NO';
 };
 export default function StudentDetailForm({
   studentData,
@@ -57,6 +58,7 @@ export default function StudentDetailForm({
       interestingActivity: studentData?.interestingActivity,
       teacherMemo: studentData?.teacherMemo,
       caution: studentData?.caution,
+      isRegister: studentData?.isRegister ? 'YES' : 'NO',
     },
   });
   const [editMode, setEditMode] = useState(false);
@@ -88,13 +90,14 @@ export default function StudentDetailForm({
   };
 
   const onSubmit: SubmitHandler<UpdateStudentForm> = async (data: UpdateStudentForm) => {
-    const { entranceDate, birthDate, day, time, ...rest } = data;
+    const { entranceDate, birthDate, day, time, isRegister, ...rest } = data;
     const body = {
       ...rest,
       entranceDate: moment(entranceDate, 'YYYY.MM.DD').toDate(),
       birthDate: moment(birthDate, 'YYYY.MM.DD').toDate(),
       day: day.map(Number).filter(Boolean),
       time: time.map(Number).filter(Boolean),
+      isRegister: isRegister === 'YES' ? true : false,
     };
     try {
       await fetch(`/api/student/${studentData?.id}`, {
@@ -310,6 +313,13 @@ export default function StudentDetailForm({
           </FlexRowItem>
           <FlexRowItem>
             <Label>등록 여부</Label>
+            <Select
+              disabled={!editMode}
+              {...register('isRegister', { required: true })}
+            >
+              <Option value={'YES'}>등록</Option>
+              <Option value={'NO'}>퇴원</Option>
+            </Select>
           </FlexRowItem>
         </FlexRow>
         <div>


### PR DESCRIPTION
# Wonderart-CRM #58 Student 테이블에 '등록여부' 컬럼 추가

## 작업 목적

- Student 테이블에 '등록여부' 컬럼을 추가하고 이와 관련된 코드들 수정

## 작업 내용

- prisma schema 에 있는 Student 모델 수정
   * 저작권 동의 컬럼을 `agree`에서 `isCopyrightAgree` 로 수정
   * 등록 여부 컬럼 `isRegister` 추가
   
- 입학원서 페이지에서 '등록여부' 코드 추가
- 학원생 페이지에서 '등록여부' 코드 추가

## 해당 PR에서 테스트할 방법을 작성해 주세요

1. prisma 스키마 파일이 변경되었기 때문에 터미널에서  `npx prisma generate` 명령어를 실행해 주세요.
2. 입학원서 페이지에서 새로운 학생을 등록해 주세요.
3. 학원생 페이지에서 생성한 학생 정보를 클릭하여 상세페이지로 이동해 주세요.
4. '수정하기' 버튼을 클릭 후 등록 여부 값을 변경한 뒤 '수정완료' 버튼을 클릭해 주세요.

## 첨부

![스크린샷 2023-09-18 230552](https://github.com/GiSeok-Hong/wonderart-crm/assets/48499094/ae84f249-1734-4335-a8bf-a16546fa0483)


## 관련된 이슈, 커밋, PR

- ISSUE #58 

## 체크리스트

- [x] 빌드 체크 하셨나요?
- [x] PR의 내용을 짐작할 수 있는 적절한 제목을 썼나요?
- [x] 작업 목적은 명확하게 의미 전달이 가능한가요?
- [x] 작업 내용은 간결하게 끝나는 문장인가요?
- [x] 첨부는 기능을 충분히 포함하고 있나요?
- [x] 관련 이슈나 티켓, PR을 포함했나요?
