### PR TITLE
Wonderart-CRM #59 선생님 리스트 페이지 개발

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -4,6 +4,12 @@ const withPWA = require('next-pwa')({
   disable: process.env.NODE_ENV === 'development',
 });
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  images: {
+    dangerouslyAllowSVG: true,
+    contentDispositionType: 'attachment',
+    contentSecurityPolicy: "default-src 'self'; script-src 'none'; sandbox;",
+  },
+};
 
 module.exports = withPWA(nextConfig);

--- a/public/icons/plus.svg
+++ b/public/icons/plus.svg
@@ -1,0 +1,11 @@
+<svg width="35" height="35" viewBox="0 0 35 35" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="Frame 42" clip-path="url(#clip0_469_128)">
+<path id="Vector 1" d="M17.5 0V35" stroke="white" stroke-width="5"/>
+<path id="Vector 2" d="M0 17.5H35" stroke="white" stroke-width="5"/>
+</g>
+<defs>
+<clipPath id="clip0_469_128">
+<rect width="35" height="35" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/app/api/teacher/route.ts
+++ b/src/app/api/teacher/route.ts
@@ -1,0 +1,7 @@
+import { getTeacherList } from "@/service/teacher";
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  const teacherList = await getTeacherList();
+  return NextResponse.json(teacherList, { status: 200 });
+}

--- a/src/app/students/page.tsx
+++ b/src/app/students/page.tsx
@@ -8,5 +8,10 @@ export const metadata: Metadata = {
 };
 
 export default async function ListPage() {
-  return <StudentTable />;
+  return (
+    <>
+      <h2 className="text-bold text-2xl text-center mb-4">학생 목록</h2>
+      <StudentTable />
+    </>
+  );
 }

--- a/src/app/teachers/page.tsx
+++ b/src/app/teachers/page.tsx
@@ -1,4 +1,5 @@
 import TeacherTable from '@/components/TeacherTable';
+import { createPortal } from 'react-dom';
 
 export default function TeacherList() {
   return (

--- a/src/app/teachers/page.tsx
+++ b/src/app/teachers/page.tsx
@@ -1,0 +1,10 @@
+import TeacherTable from '@/components/TeacherTable';
+
+export default function TeacherList() {
+  return (
+    <>
+      <h2 className="text-bold text-2xl text-center mb-4">선생님 목록</h2>
+      <TeacherTable />
+    </>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -64,17 +64,17 @@ export default function Header() {
             {navList.map((item) => (
               <li
                 key={item.href}
-                className={
-                  'hover:text-primary-color' +
-                  (pathname === item.href ? ' text-primary-color font-bold' : '') +
-                  (item.href === '/list' && pathname.includes(`/list/`) ? ' text-primary-color font-bold' : '')
-                }
+                className={'hover:text-primary-color' + (pathname === item.href ? ' text-primary-color font-bold' : '')}
               >
                 <Link href={item.href}>{item.text}</Link>
               </li>
             ))}
             {session.user.result.role === 'MASTER' && (
-              <li>
+              <li
+                className={
+                  'hover:text-primary-color' + (pathname.includes('teachers') ? ' text-primary-color font-bold' : '')
+                }
+              >
                 <Link href="/teachers">선생님목록</Link>
               </li>
             )}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -23,6 +23,10 @@ const navList = [
     href: '/students',
     text: '학원생',
   },
+  {
+    href: '/teachers',
+    text: '선생님목록',
+  },
 ];
 
 export default function Header() {
@@ -39,7 +43,7 @@ export default function Header() {
         href="/"
         className="flex items-center gap-2"
       >
-        <div className="w-[100px] h-[100px] relative">
+        <div className="w-[26px] h-[26px] relative">
           <Image
             src={`/images/logo-img.png`}
             alt="logo image"
@@ -48,7 +52,7 @@ export default function Header() {
             priority
           />
         </div>
-        <div className="w-[327px] h-[80px] relative">
+        <div className="w-[109px] h-[26px] relative">
           <Image
             src={`/images/logo-text.png`}
             alt="logo text image"

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -23,10 +23,6 @@ const navList = [
     href: '/students',
     text: '학원생',
   },
-  {
-    href: '/teachers',
-    text: '선생님목록',
-  },
 ];
 
 export default function Header() {
@@ -77,6 +73,11 @@ export default function Header() {
                 <Link href={item.href}>{item.text}</Link>
               </li>
             ))}
+            {session.user.result.role === 'MASTER' && (
+              <li>
+                <Link href="/teachers">선생님목록</Link>
+              </li>
+            )}
             <SignInButton />
           </ul>
         </nav>

--- a/src/components/StudentTable.tsx
+++ b/src/components/StudentTable.tsx
@@ -26,12 +26,6 @@ export default function StudentTable() {
     getStudentList();
   }, []);
 
-  const Th = ({ children }: { children: ReactNode }) => {
-    return <th className={`${TABLE_BORDER} p-2 bg-primary-color text-white`}>{children}</th>;
-  };
-  const Td = ({ children }: { children: ReactNode }) => {
-    return <td className={`${TABLE_BORDER} p-2`}>{children}</td>;
-  };
   return (
     <div className="flex flex-col gap-5">
       <StudentSearchInput
@@ -80,3 +74,10 @@ export default function StudentTable() {
     </div>
   );
 }
+
+const Th = ({ children }: { children: ReactNode }) => {
+  return <th className={`${TABLE_BORDER} p-2 bg-primary-color text-white`}>{children}</th>;
+};
+const Td = ({ children }: { children: ReactNode }) => {
+  return <td className={`${TABLE_BORDER} p-2`}>{children}</td>;
+};

--- a/src/components/TeacherTable.tsx
+++ b/src/components/TeacherTable.tsx
@@ -64,6 +64,7 @@ export default function TeacherTable() {
           className="fixed bottom-5 right-5 border rounded-full bg-primary-color text-white w-20 h-20 flex items-center justify-center text-4xl"
           onClick={() => {
             console.log('미구현기능');
+            return;
             setOpenModal(true);
           }}
         >

--- a/src/components/TeacherTable.tsx
+++ b/src/components/TeacherTable.tsx
@@ -1,30 +1,27 @@
-import { type ReactNode } from 'react';
+'use client';
+import { getTeacherList } from '@/service/teacher';
+import { Teacher } from '@prisma/client';
+import { useEffect, type ReactNode, useState } from 'react';
+import { createPortal } from 'react-dom';
+import plusIcon from '../../public/icons/plus.svg';
+import Image from 'next/image';
 
 const TABLE_BORDER = 'border border-black';
 
 const LABEL = ['이름', '이메일', '휴대폰번호'];
 
 export default function TeacherTable() {
-  const teacherList = [
-    {
-      id: 1,
-      name: '김원더',
-      email: 'e@gmail.com',
-      phone: '010-1234-5678',
-    },
-    {
-      id: 2,
-      name: '이원더',
-      email: 'e@gmail.com',
-      phone: '010-1234-5678',
-    },
-    {
-      id: 3,
-      name: '박원더',
-      email: 'e@gmail.com',
-      phone: '010-1234-5678',
-    },
-  ];
+  const [teacherList, setTeacherList] = useState<Teacher[]>([]);
+
+  const [openModal, setOpenModal] = useState(false);
+
+  useEffect(() => {
+    (async function () {
+      const teacherList = await fetch('/api/teacher').then((res) => res.json());
+      setTeacherList(teacherList);
+    })();
+  }, []);
+
   return (
     <div className="flex flex-col gap-5">
       <table className={`${TABLE_BORDER} border-collapse w-full mb-5`}>
@@ -50,6 +47,34 @@ export default function TeacherTable() {
           })}
         </tbody>
       </table>
+      {openModal &&
+        createPortal(
+          <>
+            <div className="fixed inset-0 bg-black opacity-50 z-10"></div>
+            <div className="fixed inset-0 flex justify-center items-center z-10">
+              <div className="bg-white w-[500px] h-[500px] flex justify-center items-center">
+                <h1>선생님 등록</h1>
+              </div>
+            </div>
+          </>,
+          document.body,
+        )}
+      {createPortal(
+        <button
+          className="fixed bottom-5 right-5 border rounded-full bg-primary-color text-white w-20 h-20 flex items-center justify-center text-4xl"
+          onClick={() => {
+            setOpenModal(true);
+          }}
+        >
+          <Image
+            src={plusIcon}
+            width={35}
+            height={35}
+            alt="plus"
+          />
+        </button>,
+        document.body,
+      )}
     </div>
   );
 }

--- a/src/components/TeacherTable.tsx
+++ b/src/components/TeacherTable.tsx
@@ -63,6 +63,7 @@ export default function TeacherTable() {
         <button
           className="fixed bottom-5 right-5 border rounded-full bg-primary-color text-white w-20 h-20 flex items-center justify-center text-4xl"
           onClick={() => {
+            console.log('미구현기능');
             setOpenModal(true);
           }}
         >

--- a/src/components/TeacherTable.tsx
+++ b/src/components/TeacherTable.tsx
@@ -1,0 +1,63 @@
+import { type ReactNode } from 'react';
+
+const TABLE_BORDER = 'border border-black';
+
+const LABEL = ['이름', '이메일', '휴대폰번호'];
+
+export default function TeacherTable() {
+  const teacherList = [
+    {
+      id: 1,
+      name: '김원더',
+      email: 'e@gmail.com',
+      phone: '010-1234-5678',
+    },
+    {
+      id: 2,
+      name: '이원더',
+      email: 'e@gmail.com',
+      phone: '010-1234-5678',
+    },
+    {
+      id: 3,
+      name: '박원더',
+      email: 'e@gmail.com',
+      phone: '010-1234-5678',
+    },
+  ];
+  return (
+    <div className="flex flex-col gap-5">
+      <table className={`${TABLE_BORDER} border-collapse w-full mb-5`}>
+        <thead>
+          <tr>
+            {LABEL.map((label) => {
+              return <Th key={label}>{label}</Th>;
+            })}
+          </tr>
+        </thead>
+        <tbody>
+          {teacherList.map((teacher, index) => {
+            return (
+              <tr
+                key={teacher.id}
+                className={`text-center ${index % 2 === 0 ? 'transparent' : 'bg-gray-EEE'}`}
+              >
+                <Td>{teacher.name}</Td>
+                <Td>{teacher.email}</Td>
+                <Td>{teacher.phone}</Td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+const Th = ({ children }: { children: ReactNode }) => {
+  return <th className={`${TABLE_BORDER} p-2 bg-primary-color text-white`}>{children}</th>;
+};
+
+const Td = ({ children }: { children: ReactNode }) => {
+  return <td className={`${TABLE_BORDER} p-2`}>{children}</td>;
+};

--- a/src/components/TeacherTable.tsx
+++ b/src/components/TeacherTable.tsx
@@ -1,5 +1,4 @@
 'use client';
-import { getTeacherList } from '@/service/teacher';
 import { Teacher } from '@prisma/client';
 import { useEffect, type ReactNode, useState } from 'react';
 import { createPortal } from 'react-dom';

--- a/src/components/TeacherTable.tsx
+++ b/src/components/TeacherTable.tsx
@@ -46,36 +46,6 @@ export default function TeacherTable() {
           })}
         </tbody>
       </table>
-      {openModal &&
-        createPortal(
-          <>
-            <div className="fixed inset-0 bg-black opacity-50 z-10"></div>
-            <div className="fixed inset-0 flex justify-center items-center z-10">
-              <div className="bg-white w-[500px] h-[500px] flex justify-center items-center">
-                <h1>선생님 등록</h1>
-              </div>
-            </div>
-          </>,
-          document.body,
-        )}
-      {createPortal(
-        <button
-          className="fixed bottom-5 right-5 border rounded-full bg-primary-color text-white w-20 h-20 flex items-center justify-center text-4xl"
-          onClick={() => {
-            console.log('미구현기능');
-            return;
-            setOpenModal(true);
-          }}
-        >
-          <Image
-            src={plusIcon}
-            width={35}
-            height={35}
-            alt="plus"
-          />
-        </button>,
-        document.body,
-      )}
     </div>
   );
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,5 +1,5 @@
 export { default } from 'next-auth/middleware';
 
 export const config = {
-  matcher: ['/students/:path*', '/registration', '/schedule'],
+  matcher: ['/students/:path*', '/registration', '/schedule', '/teachers/:path*'],
 };

--- a/src/service/teacher.ts
+++ b/src/service/teacher.ts
@@ -1,0 +1,6 @@
+import { prisma } from "../../lib/prisma";
+
+export async function getTeacherList() {
+  const teacherList = await prisma.teacher.findMany();
+  return teacherList;
+}

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -3,12 +3,20 @@ import NextAuth from 'next-auth';
 declare module 'next-auth' {
   interface Session {
     user: {
-      id: number;
-      name: string;
-      email: string;
-      phone: string;
-      role: string;
-      accessToken: string;
+      exp: number;
+      iat: number;
+      jti: string;
+      message: string;
+      result: {
+        id: number;
+        name: string;
+        email: string;
+        phone: string;
+        role: string;
+        accessToken: string;
+      };
+      status: number;
+      success: boolean;
     };
   }
 }


### PR DESCRIPTION
# Wonderart-CRM #59 선생님 리스트 페이지 개발

## 작업 목적
- 마스터 계정일 경우, 선생님 리스트 페이지에 접근하고 확인할 수 있도록 합니다.
## 작업 내용
- 상단 nav바 유저 role이 master일 경우 선생님 목록 메뉴가 보이도록 수정
- svg 설정 추가
- plus 버튼 UI 개발
- 선생님 목록 API 생성
- 선생님 목록 페이지 UI 개발

## 해당 PR에서 테스트할 방법을 작성해 주세요
- [x] 마스터 계정일 경우만 상단에 선생님 목록 메뉴 보이도록 수정
- [ ] +버튼 추가 (기능 미구현)
- [ ] 선생님 목록 표시 유무

## 첨부
![image](https://github.com/GiSeok-Hong/wonderart-crm/assets/20733450/03a70145-60cc-462c-ba4d-eff3a3c240fd)

## 관련된 이슈, 커밋, PR
- ISSUE #46

## 체크리스트

- [ ] 빌드 체크 하셨나요?
- [ ] PR의 내용을 짐작할 수 있는 적절한 제목을 썼나요?
- [ ] 작업 목적은 명확하게 의미 전달이 가능한가요?
- [ ] 작업 내용은 간결하게 끝나는 문장인가요?
- [x] 첨부는 기능을 충분히 포함하고 있나요?
- [x] 관련 이슈나 티켓, PR을 포함했나요?
