### PR TITLE
Wonderart-CRM #62 시간표 페이지 mock data 대신 현재 학생 데이터가 나오도록 수정

### DIFF
--- a/src/app/schedule/page.tsx
+++ b/src/app/schedule/page.tsx
@@ -1,4 +1,4 @@
-import HeaderCalendar from '@/components/Calendar/HeaderCalendar';
+import FooterCalendar from '@/components/Calendar/FooterCalendar';
 import WeeklyCalendar from '@/components/Calendar/WeeklyCalendar';
 import ScheduleTextarea from '@/components/ScheduleTextarea';
 import { Metadata } from 'next';
@@ -12,17 +12,6 @@ export default function SchedulePage() {
   return (
     <div>
       <div className="flex justify-between gap-2 mb-5">
-        <HeaderCalendar />
-        <textarea
-          name=""
-          id=""
-          cols={30}
-          rows={8}
-          className="bg-gray-EEE p-2 outline-primary-color resize-none w-2/3 h-[200px]"
-          placeholder="노트"
-        />
-      </div>
-      <div className="flex justify-between gap-2">
         <WeeklyCalendar />
         <div className="mt-[38px] pt-[67px]">
           <ScheduleTextarea />
@@ -31,6 +20,17 @@ export default function SchedulePage() {
           <ScheduleTextarea />
           <ScheduleTextarea />
         </div>
+      </div>
+      <div className="flex justify-between gap-2 mb-5">
+        <FooterCalendar />
+        <textarea
+          name=""
+          id=""
+          cols={30}
+          rows={8}
+          className="bg-gray-EEE p-2 outline-primary-color resize-none w-2/3 h-[200px]"
+          placeholder="노트"
+        />
       </div>
     </div>
   );

--- a/src/app/schedule/page.tsx
+++ b/src/app/schedule/page.tsx
@@ -1,6 +1,7 @@
 import FooterCalendar from '@/components/Calendar/FooterCalendar';
 import WeeklyCalendar from '@/components/Calendar/WeeklyCalendar';
 import ScheduleTextarea from '@/components/ScheduleTextarea';
+import { getStudentList } from '@/service/student';
 import { Metadata } from 'next';
 
 export const metadata: Metadata = {
@@ -8,12 +9,14 @@ export const metadata: Metadata = {
   description: '원더아트 스튜디오 시간표 페이지입니다.',
 };
 
-export default function SchedulePage() {
+export default async function SchedulePage() {
+  const students = await getStudentList();
+
   return (
     <div>
       <div className="flex justify-between gap-2 mb-5">
-        <WeeklyCalendar />
-        <div className="mt-[38px] pt-[67px]">
+        <WeeklyCalendar studentsData={students} />
+        <div className="mt-[38px] pt-[21px]">
           <ScheduleTextarea />
           <ScheduleTextarea />
           <ScheduleTextarea />
@@ -21,14 +24,14 @@ export default function SchedulePage() {
           <ScheduleTextarea />
         </div>
       </div>
-      <div className="flex justify-between gap-2 mb-5">
+      <div className="flex justify-between gap-2">
         <FooterCalendar />
         <textarea
           name=""
           id=""
           cols={30}
           rows={8}
-          className="bg-gray-EEE p-2 outline-primary-color resize-none w-2/3 h-[200px]"
+          className="bg-gray-EEE p-2 outline-primary-color resize-none w-2/3 h-[200px] mb-10"
           placeholder="노트"
         />
       </div>

--- a/src/components/Calendar/Calendar.css
+++ b/src/components/Calendar/Calendar.css
@@ -89,7 +89,7 @@ button.rbc-input::-moz-focus-inner {
   font-weight: bold;
   font-size: 90%;
   min-height: 0;
-  border-bottom: 1px solid #ddd;
+  /* border-bottom: 1px solid #ddd; */
 }
 .rbc-header + .rbc-header {
   border-left: 1px solid #ddd;
@@ -298,8 +298,10 @@ button.rbc-input::-moz-focus-inner {
   outline: 5px auto #3b99fc;
 }
 
+/* 수정: display: none - 시간 보이지 않기 위해 추가 */
 .rbc-event-label {
   font-size: 80%;
+  display: none;
 }
 
 .rbc-event-overlaps {
@@ -744,6 +746,12 @@ button.rbc-input::-moz-focus-inner {
 .rbc-time-view .rbc-allday-cell + .rbc-allday-cell {
   border-left: 1px solid #ddd;
 }
+
+/* 수정: .rbc-allday-cell display:none 추가 */
+.rbc-allday-cell {
+  display: none;
+}
+
 .rbc-time-view .rbc-allday-events {
   position: relative;
   z-index: 4;
@@ -766,7 +774,7 @@ button.rbc-input::-moz-focus-inner {
   -ms-flex-direction: row;
   flex-direction: row;
   /* 수정: height 값 추가 */
-  height: 65px;
+  height: 21px;
 }
 .rbc-time-header.rbc-overflowing {
   border-right: 1px solid #ddd;

--- a/src/components/Calendar/FooterCalendar.tsx
+++ b/src/components/Calendar/FooterCalendar.tsx
@@ -4,15 +4,15 @@ import { Calendar, momentLocalizer } from 'react-big-calendar';
 import moment from 'moment';
 import './Calendar.css';
 import 'moment/locale/ko';
-import HeaderCalendarToolbar from './HeaderCalendarToolbar';
+import FooterCalendarToolbar from './FooterCalendarToolbar';
 
-export default function HeaderCalendar() {
+export default function FooterCalendar() {
   const localizer = momentLocalizer(moment);
   return (
     <Calendar
       localizer={localizer}
       style={{ height: 200 }}
-      components={{ toolbar: HeaderCalendarToolbar }}
+      components={{ toolbar: FooterCalendarToolbar }}
     />
   );
 }

--- a/src/components/Calendar/FooterCalendarToolbar.tsx
+++ b/src/components/Calendar/FooterCalendarToolbar.tsx
@@ -1,6 +1,6 @@
 import { BsFillCaretLeftFill, BsFillCaretRightFill } from 'react-icons/bs';
 
-export default function HeaderCalendarToolbar(props: { onNavigate: Function; date: Date }) {
+export default function FooterCalendarToolbar(props: { onNavigate: Function; date: Date }) {
   const { date, onNavigate } = props;
 
   const navigate = (action: string) => {

--- a/src/components/Calendar/WeeklyCalendar.tsx
+++ b/src/components/Calendar/WeeklyCalendar.tsx
@@ -198,17 +198,6 @@ export default function WeeklyCalendar({ studentsData }: { studentsData: Student
         onEventResize={resizeEvent}
         resizable
       />
-      {/* <div className="border-[1px] border-black mt-2 p-2">  
-        {Object.entries(counters).map(([name, count]) => (
-          <div
-            draggable="true"
-            key={name}
-            onDragStart={() => handleDragStart({ title: formatName(name, count), name })}
-          >
-            {formatName(name, count)}
-          </div>
-        ))}
-      </div> */}
     </div>
   );
 }


### PR DESCRIPTION
# Wonderart-CRM #62 시간표 페이지 mock data 대신 현재 학생 데이터가 나오도록 수정

## 작업 목적

- 시간표 페이지 mock data 대신 현재 학생 데이터가 나오도록 수정

## 작업 내용

- 등록되어 있는 학생 정보를 토대로 이벤트 보여주기
- 기타 시간표 페이지 UI 작업

## 해당 PR에서 테스트할 방법을 작성해 주세요

- `npm run dev` 실행 후 시간표 페이지로 이동

## 첨부

![스크린샷 2023-09-24 180513](https://github.com/GiSeok-Hong/wonderart-crm/assets/48499094/ac71b7b3-bd09-4f7c-9e93-422bc6fae217)


## 관련된 이슈, 커밋, PR

- ISSUE #62 

## 체크리스트

- [x] 빌드 체크 하셨나요?
- [x] PR의 내용을 짐작할 수 있는 적절한 제목을 썼나요?
- [x] 작업 목적은 명확하게 의미 전달이 가능한가요?
- [x] 작업 내용은 간결하게 끝나는 문장인가요?
- [x] 첨부는 기능을 충분히 포함하고 있나요?
- [x] 관련 이슈나 티켓, PR을 포함했나요?
