### PR TITLE
Wonderart-CRM #76  연락처 표기 시 ' - ' 로 구분하도록 작업

### DIFF
--- a/src/components/StudentTable.tsx
+++ b/src/components/StudentTable.tsx
@@ -6,6 +6,7 @@ import StudentSearchInput from './StudentSearchInput';
 import { useRouter } from 'next/navigation';
 import { type Student } from '@prisma/client';
 import { translateWord } from '@/helper/sex';
+import { phoneFormat } from '@/helper/phone';
 
 const TABLE_BORDER = 'border border-black';
 
@@ -65,7 +66,7 @@ export default function StudentTable() {
                 <Td>{student.name}</Td>
                 <Td>만 {getAge(student.birthDate)}세</Td>
                 <Td>{translateWord(student.sex)}</Td>
-                <Td>{student.guardian.phone}</Td>
+                <Td>{phoneFormat(student.guardian.phone)}</Td>
                 <Td>{student.school}</Td>
               </tr>
             );

--- a/src/components/TeacherTable.tsx
+++ b/src/components/TeacherTable.tsx
@@ -6,6 +6,7 @@ const PlusButton = dynamic(() => import('@/components/PlusButton'), { ssr: false
 import Modal from 'react-modal';
 import { SubmitErrorHandler, SubmitHandler, useForm } from 'react-hook-form';
 import toast from 'react-hot-toast';
+import { phoneFormat } from '@/helper/phone';
 
 const TABLE_BORDER = 'border border-black';
 
@@ -132,7 +133,7 @@ export default function TeacherTable() {
               >
                 <Td>{teacher.name}</Td>
                 <Td>{teacher.email}</Td>
-                <Td>{teacher.phone}</Td>
+                <Td>{phoneFormat(teacher.phone)}</Td>
               </tr>
             );
           })}

--- a/src/components/TeacherTable.tsx
+++ b/src/components/TeacherTable.tsx
@@ -9,7 +9,7 @@ import toast from 'react-hot-toast';
 
 const TABLE_BORDER = 'border border-black';
 
-const LABEL = ['이름', '이메일', '휴대폰번호'];
+const LABEL = ['이름', '이메일', '연락처'];
 
 const customStyles = {
   content: {
@@ -173,7 +173,7 @@ export default function TeacherTable() {
               className="w-24"
               htmlFor="password"
             >
-              password
+              비밀번호
             </label>
             <input
               className="border border-black flex-1"
@@ -187,7 +187,7 @@ export default function TeacherTable() {
               className="w-24"
               htmlFor="email"
             >
-              email
+              이메일
             </label>
             <input
               className="border border-black flex-1"
@@ -201,7 +201,7 @@ export default function TeacherTable() {
               className="w-24"
               htmlFor="phone"
             >
-              핸드폰번호
+              연락처
             </label>
             <input
               className="border border-black flex-1"

--- a/src/helper/phone.ts
+++ b/src/helper/phone.ts
@@ -1,7 +1,3 @@
 export function phoneFormat(phone: string) {
-  if (!phone) {
-    return '';
-  } else {
-    return phone.slice(0, 3) + '-' + phone.slice(3, 7) + '-' + phone.slice(7);
-  }
+  return phone.slice(0, 3) + '-' + phone.slice(3, 7) + '-' + phone.slice(7);
 }

--- a/src/helper/phone.ts
+++ b/src/helper/phone.ts
@@ -1,0 +1,7 @@
+export function phoneFormat(phone: string) {
+  if (phone === undefined || !phone) {
+    return '';
+  } else {
+    return phone.slice(0, 3) + '-' + phone.slice(3, 7) + '-' + phone.slice(7);
+  }
+}

--- a/src/helper/phone.ts
+++ b/src/helper/phone.ts
@@ -1,5 +1,5 @@
 export function phoneFormat(phone: string) {
-  if (phone === undefined || !phone) {
+  if (!phone) {
     return '';
   } else {
     return phone.slice(0, 3) + '-' + phone.slice(3, 7) + '-' + phone.slice(7);


### PR DESCRIPTION
# Wonderart-CRM #76  연락처 표기 시 ' - ' 로 구분하도록 작업

## 작업 목적

- 사용자 요청 사항 : 연락처 보일 때 ' - ' 로 나눠서 보이도록 변경 요청

## 작업 내용

- 학생 목록 페이지의 '보호자 연락처' 항목
- 선생님 목록 페이지의 '휴대폰번호' 항목
- 텍스트 수정 (휴대폰번호 -> 연락처, email -> 이메일, password -> 비밀번호) 

## 해당 PR에서 테스트할 방법을 작성해 주세요
학원생, 선생님 페이지에서 확인

## 첨부
![스크린샷 2023-11-15 173745](https://github.com/GiSeok-Hong/wonderart-crm/assets/48499094/0c87a898-662b-49ae-8525-f8b4cfaec21d)


## 관련된 이슈, 커밋, PR

- ISSUE #76 

## 체크리스트

- [x] 빌드 체크 하셨나요?
- [x] PR의 내용을 짐작할 수 있는 적절한 제목을 썼나요?
- [x] 작업 목적은 명확하게 의미 전달이 가능한가요?
- [x] 작업 내용은 간결하게 끝나는 문장인가요?
- [x] 첨부는 기능을 충분히 포함하고 있나요?
- [x] 관련 이슈나 티켓, PR을 포함했나요?
