### PR TITLE
Wonderart-CRM #81 학생 상세 페이지에서 수업이 하나인 학생도 수업 시간 항목이 2개가 나오는 현상 수정

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -64,7 +64,11 @@ export default function Header() {
             {navList.map((item) => (
               <li
                 key={item.href}
-                className={'hover:text-primary-color' + (pathname === item.href ? ' text-primary-color font-bold' : '')}
+                className={
+                  'hover:text-primary-color' +
+                  (pathname === item.href ? ' text-primary-color font-bold' : '') +
+                  (item.href === '/students' && pathname.includes('/students/') ? ' text-primary-color font-bold' : '')
+                }
               >
                 <Link href={item.href}>{item.text}</Link>
               </li>
@@ -75,7 +79,7 @@ export default function Header() {
                   'hover:text-primary-color' + (pathname.includes('teachers') ? ' text-primary-color font-bold' : '')
                 }
               >
-                <Link href="/teachers">선생님목록</Link>
+                <Link href="/teachers">선생님</Link>
               </li>
             )}
             <SignInButton />

--- a/src/components/StudentDetailForm.tsx
+++ b/src/components/StudentDetailForm.tsx
@@ -39,7 +39,7 @@ export default function StudentDetailForm({
   studentData: Student & { guardian: { name: string; phone: string } };
 }) {
   const router = useRouter();
-  const { register, handleSubmit, setValue, watch } = useForm<UpdateStudentForm>({
+  const { register, handleSubmit, setValue, watch, unregister } = useForm<UpdateStudentForm>({
     defaultValues: {
       address: studentData?.address,
       birthDate: moment(studentData?.birthDate).format('YYYY.MM.DD'),
@@ -62,6 +62,8 @@ export default function StudentDetailForm({
     },
   });
   const [editMode, setEditMode] = useState(false);
+
+  const [addMode, setAddMode] = useState(studentData.day[1] !== undefined && studentData.time[1] !== undefined);
 
   const age = getAge(studentData?.birthDate);
 
@@ -195,38 +197,60 @@ export default function StudentDetailForm({
                 })}
               </Select>
             </FlexColumnItem>
-            <FlexColumnItem>
-              <Select
-                disabled={!editMode}
-                {...register('day.1')}
+
+            {addMode ? (
+              <FlexColumnItem>
+                <Select
+                  disabled={!editMode}
+                  {...register('day.1')}
+                >
+                  {DAY_OPTION.map((day) => {
+                    return (
+                      <Option
+                        key={day.value}
+                        value={day.value}
+                      >
+                        {day.name}
+                      </Option>
+                    );
+                  })}
+                </Select>
+                <Select
+                  disabled={!editMode}
+                  {...register('time.1')}
+                >
+                  {TIME_OPTION.map((time) => {
+                    return (
+                      <Option
+                        key={time.value}
+                        value={time.value}
+                      >
+                        {time.name}
+                      </Option>
+                    );
+                  })}
+                </Select>
+              </FlexColumnItem>
+            ) : (
+              <></>
+            )}
+            {editMode ? (
+              <button
+                type="button"
+                className="border px-1"
+                onClick={() => {
+                  if (addMode) {
+                    unregister('time.1');
+                    unregister('day.1');
+                  }
+                  setAddMode(!addMode);
+                }}
               >
-                {DAY_OPTION.map((day) => {
-                  return (
-                    <Option
-                      key={day.value}
-                      value={day.value}
-                    >
-                      {day.name}
-                    </Option>
-                  );
-                })}
-              </Select>
-              <Select
-                disabled={!editMode}
-                {...register('time.1')}
-              >
-                {TIME_OPTION.map((time) => {
-                  return (
-                    <Option
-                      key={time.value}
-                      value={time.value}
-                    >
-                      {time.name}
-                    </Option>
-                  );
-                })}
-              </Select>
-            </FlexColumnItem>
+                {!addMode ? '추가' : '삭제'}
+              </button>
+            ) : (
+              <></>
+            )}
           </FlexRowItem>
         </FlexRow>
         <FlexRow>

--- a/src/components/StudentDetailForm.tsx
+++ b/src/components/StudentDetailForm.tsx
@@ -151,6 +151,7 @@ export default function StudentDetailForm({
             <Input
               disabled={!editMode}
               maxLength={10}
+              style={{ width: '150px' }}
               {...register('entranceDate', {
                 required: true,
                 minLength: 10,
@@ -233,6 +234,7 @@ export default function StudentDetailForm({
             <Label>학생명</Label>
             <Input
               disabled={!editMode}
+              style={{ width: '150px' }}
               {...register('name', { required: true, maxLength: 5 })}
             />
           </FlexRowItem>
@@ -240,6 +242,7 @@ export default function StudentDetailForm({
             <Label>학생 연락처</Label>
             <Input
               disabled={!editMode}
+              style={{ width: '150px' }}
               {...register('phone', {
                 minLength: 11,
                 maxLength: 11,
@@ -253,6 +256,7 @@ export default function StudentDetailForm({
             <Input
               disabled={!editMode}
               maxLength={10}
+              style={{ width: '150px' }}
               {...register('birthDate', {
                 required: true,
                 minLength: 10,
@@ -278,6 +282,7 @@ export default function StudentDetailForm({
             <Label>보호자명</Label>
             <Input
               disabled={!editMode}
+              style={{ width: '150px' }}
               {...register('guardianName', { maxLength: 5 })}
             />
           </FlexRowItem>
@@ -285,6 +290,7 @@ export default function StudentDetailForm({
             <Label>보호자 연락처</Label>
             <Input
               disabled={!editMode}
+              style={{ width: '150px' }}
               {...register('guardianPhone', {
                 minLength: 11,
                 maxLength: 11,
@@ -307,6 +313,7 @@ export default function StudentDetailForm({
             <Label>학교 / 유치원</Label>
             <Input
               disabled={!editMode}
+              style={{ width: '150px' }}
               {...register('school', { maxLength: 20 })}
             />
           </FlexRowItem>
@@ -444,7 +451,7 @@ interface DivProps extends React.HTMLAttributes<HTMLDivElement> {}
 const FlexRow = ({ children, ...props }: DivProps) => {
   return (
     <div
-      className="flex justify-between gap-4"
+      className="flex gap-4"
       {...props}
     >
       {children}
@@ -455,7 +462,7 @@ const FlexRow = ({ children, ...props }: DivProps) => {
 const FlexRowItem = ({ children, ...props }: DivProps) => {
   return (
     <div
-      className="flex gap-3 items-center w-full"
+      className="flex gap-2 items-center"
       {...props}
     >
       {children}
@@ -478,7 +485,7 @@ interface LabelProps extends React.LabelHTMLAttributes<HTMLLabelElement> {}
 const Label = ({ children, ...props }: LabelProps) => {
   return (
     <label
-      className="w-28 text-black text-lg font-normal"
+      className="w-[120px] text-black text-lg font-normal"
       {...props}
     >
       {children}

--- a/src/components/StudentDetailForm.tsx
+++ b/src/components/StudentDetailForm.tsx
@@ -268,13 +268,26 @@ export default function StudentDetailForm({
           </FlexRowItem>
           <FlexRowItem>
             <Label>성별</Label>
-            <Select
-              disabled={!editMode}
-              {...register('sex', { required: true })}
-            >
-              <Option value={Sex.MALE}>남</Option>
-              <Option value={Sex.FEMALE}>여</Option>
-            </Select>
+            <label className="mr-5">
+              <input
+                type="radio"
+                disabled={!editMode}
+                className="mr-2"
+                value={Sex.MALE}
+                {...register('sex', { required: true })}
+              />
+              남
+            </label>
+            <label className="mr-5">
+              <input
+                type="radio"
+                disabled={!editMode}
+                className="mr-2"
+                value={Sex.FEMALE}
+                {...register('sex', { required: true })}
+              />
+              여
+            </label>
           </FlexRowItem>
         </FlexRow>
         <FlexRow>
@@ -319,13 +332,26 @@ export default function StudentDetailForm({
           </FlexRowItem>
           <FlexRowItem>
             <Label>등록 여부</Label>
-            <Select
-              disabled={!editMode}
-              {...register('isRegister', { required: true })}
-            >
-              <Option value={'YES'}>등록</Option>
-              <Option value={'NO'}>퇴원</Option>
-            </Select>
+            <label className="mr-5">
+              <input
+                type="radio"
+                disabled={!editMode}
+                className="mr-2"
+                value={'YES'}
+                {...register('isRegister', { required: true })}
+              />
+              등록
+            </label>
+            <label className="mr-5">
+              <input
+                type="radio"
+                disabled={!editMode}
+                className="mr-2"
+                value={'NO'}
+                {...register('isRegister', { required: true })}
+              />
+              퇴원
+            </label>
           </FlexRowItem>
         </FlexRow>
         <div>
@@ -338,57 +364,63 @@ export default function StudentDetailForm({
         </div>
         <div>
           <p className="text-lg font-normal">원더아트 스튜디오를 선택한 이유</p>
-          <Select
-            disabled={!editMode}
-            {...register('reason', { required: true })}
-          >
-            {Object.entries(REASON_OPTION).map(([key, value]) => {
-              return (
-                <Option
-                  key={key}
+          {Object.entries(REASON_OPTION).map(([key, value]) => {
+            return (
+              <label
+                className="mr-5"
+                key={key}
+              >
+                <input
+                  type="radio"
+                  disabled={!editMode}
+                  className="mr-2"
                   value={key}
-                >
-                  {value}
-                </Option>
-              );
-            })}
-          </Select>
+                  {...register('reason', { required: true })}
+                />
+                {value}
+              </label>
+            );
+          })}
         </div>
         <div>
           <p className="text-lg font-normal">학부모님이 가장 중요하다고 생각하는 미술활동</p>
-          <Select
-            disabled={!editMode}
-            {...register('importantActivity')}
-          >
-            {Object.entries(GUARDIANS_INTERESTING_OPTION).map(([key, value]) => {
-              return (
-                <Option
-                  key={key}
+          {Object.entries(GUARDIANS_INTERESTING_OPTION).map(([key, value]) => {
+            return (
+              <label
+                className="mr-5"
+                key={key}
+              >
+                <input
+                  type="radio"
+                  disabled={!editMode}
+                  className="mr-2"
                   value={key}
-                >
-                  {value}
-                </Option>
-              );
-            })}
-          </Select>
+                  {...register('importantActivity', { required: true })}
+                />
+                {value}
+              </label>
+            );
+          })}
         </div>
         <div>
           <p className="text-lg font-normal">학생이 가장 흥미있어 하는 미술활동</p>
-          <Select
-            disabled={!editMode}
-            {...register('interestingActivity')}
-          >
-            {Object.entries(GUARDIANS_INTERESTING_OPTION).map(([key, value]) => {
-              return (
-                <Option
-                  key={key}
+          {Object.entries(GUARDIANS_INTERESTING_OPTION).map(([key, value]) => {
+            return (
+              <label
+                className="mr-5"
+                key={key}
+              >
+                <input
+                  type="radio"
+                  disabled={!editMode}
+                  className="mr-2"
                   value={key}
-                >
-                  {value}
-                </Option>
-              );
-            })}
-          </Select>
+                  {...register('interestingActivity', { required: true })}
+                />
+                {value}
+              </label>
+            );
+          })}
         </div>
         <div>
           <p className="text-lg font-normal">학생에 대해 특별히 알아야 하거나, 주의해야 할 점</p>


### PR DESCRIPTION
# Wonderart-CRM #81 학생 상세 페이지에서 수업이 하나인 학생도 수업 시간 항목이 2개가 나오는 현상 수정

## 작업 목적

- 사용자 요청 사항 - 학생 상세 페이지 select box 부분 수정
- 학생 등록 시 수업이 하나였던 학생일 경우 상세 페이지 최초 진입 시 하나만 나오도록 수정

## 작업 내용

- input, label 간격 조정
- 사용자 요청 사항 작업 - select box 를 radio button 형식으로 변경
- header css 조건 추가, 텍스트 수정 (선생님 목록 -> 선생님)
- 수업 시간 항목에 버튼 추가

## 해당 PR에서 테스트할 방법을 작성해 주세요

- 학생 상세 페이지로 이동하여 확인

## 첨부

![스크린샷 2023-11-21 144226](https://github.com/GiSeok-Hong/wonderart-crm/assets/48499094/51e4275a-cf8e-492a-9dc2-62c73e3b0e7b)


## 관련된 이슈, 커밋, PR

- ISSUE #72 
- ISSUE #81 

## 체크리스트

- [x] 빌드 체크 하셨나요?
- [x] PR의 내용을 짐작할 수 있는 적절한 제목을 썼나요?
- [x] 작업 목적은 명확하게 의미 전달이 가능한가요?
- [x] 작업 내용은 간결하게 끝나는 문장인가요?
- [x] 첨부는 기능을 충분히 포함하고 있나요?
- [x] 관련 이슈나 티켓, PR을 포함했나요?
