### PR TITLE
Wonderart-CRM #86 Prisma schema 선생님 연락처 unique 설정

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -46,7 +46,7 @@ model Guardian {
 model Teacher {
   id Int @id @default(autoincrement())
   name String @db.VarChar(5)
-  phone String @db.Char(11)
+  phone String @unique @db.Char(11)
   email String @unique @db.VarChar(30)
   password String @db.VarChar(20)
   role Role @default(TEACHER)

--- a/src/service/teacher.ts
+++ b/src/service/teacher.ts
@@ -1,4 +1,3 @@
-import { Prisma } from '@prisma/client';
 import { prisma } from '../../lib/prisma';
 
 export async function getTeacherList() {

--- a/src/service/teacher.ts
+++ b/src/service/teacher.ts
@@ -1,3 +1,4 @@
+import { Prisma } from '@prisma/client';
 import { prisma } from '../../lib/prisma';
 
 export async function getTeacherList() {
@@ -12,13 +13,21 @@ export async function createTeacher(data: { name: string; email: string; phone: 
 
   const { email, name, phone, password } = data;
 
-  const isExist = await prisma.teacher.findUnique({
+  const isExistEmail = await prisma.teacher.findUnique({
     where: {
       email,
     },
   });
 
-  if (isExist) throw new Error('이미 존재하는 이메일입니다.');
+  if (isExistEmail) throw new Error('이미 존재하는 이메일입니다.');
+
+  const isExistPhone = await prisma.teacher.findUnique({
+    where: {
+      phone,
+    },
+  });
+
+  if (isExistPhone) throw new Error('이미 존재하는 연락처입니다.');
 
   try {
     const teacher = await prisma.teacher.create({


### PR DESCRIPTION
# Wonderart-CRM #86 Prisma schema 선생님 연락처 unique 설정

## 작업 목적

- 선생님 등록 시 중복되는 연락처일 경우 등록되지 않도록 하기 위함.

## 작업 내용

- 선생님 연락처 unique 설정
- 이미 등록된 연락처일 경우 에러 처리

## 해당 PR에서 테스트할 방법을 작성해 주세요

- `schema.prisma` 파일이 변경되었기 때문에 `npx prisma db push && npx prisma generate` 명령어 실행
- 선생님 목록 페이지에서 신규 선생님 등록 시 이미 등록된 연락처를 입력하여 확인

## 첨부
![스크린샷 2023-12-29 174436](https://github.com/GiSeok-Hong/wonderart-crm/assets/48499094/4f41067c-9a1c-4051-942e-4053642f1b75)


## 관련된 이슈, 커밋, PR

- ISSUE #86 

## 체크리스트

- [x] 빌드 체크 하셨나요?
- [x] PR의 내용을 짐작할 수 있는 적절한 제목을 썼나요?
- [x] 작업 목적은 명확하게 의미 전달이 가능한가요?
- [x] 작업 내용은 간결하게 끝나는 문장인가요?
- [x] 첨부는 기능을 충분히 포함하고 있나요?
- [x] 관련 이슈나 티켓, PR을 포함했나요?
